### PR TITLE
Improvements based on audit #1 

### DIFF
--- a/Audit1.md
+++ b/Audit1.md
@@ -1,0 +1,86 @@
+# Audit report
+
+| Name       | Information |
+|:----------:|-----------|
+| Repository | https://github.com/DePayFi/depay-ethereum-payment-processing |
+| Checked    | [DePayPaymentProcessorV1.sol](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/master/contracts/DePayPaymentProcessorV1.sol)  & [DePayPaymentProcessorV1Uniswap01.sol](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/master/contracts/DePayPaymentProcessorV1Uniswap01.sol)|
+| Branch     | [master](https://github.com/DePayFi/depay-ethereum-payment-processing) |
+| Time       | Sun, 24 Jan 2021 03:59:35 UTC |
+| Author     | Temitayo Daniel|
+
+# Result
+
+| Severity | Count     | Link |
+|:--------:|----------:|------|
+| High     | 0        |       |
+|Medium    | 0        |       | 
+| Low      | 3         |       |
+|||[L01 - Duplicate function names](#L01)|
+|||[L02 - Inconsistent  variable type](#L02)|
+|||[L03 - Lack of comments on most functions](#L03)|
+|Notes     | 1         |      |
+|||[N01 - Consider using address(0)](#N01)
+
+
+
+## L01 - Duplicate function names
+
+ Affected      | Severity  | Count | Lines |
+|:-------------:|:----------|------:|-------:|
+| DePayPaymentProcessorV1.sol  | Low    |   1   | [68-75](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L68l#L68-L75)
+
+There are two private functions that share the same name `_ensureBalance`, It is advised to change one of them so as to avoid confusion especially when using them in other functions.
+
+```solidity 
+ function _ensureBalance(address tokenOut, uint balanceBefore) private {
+    require(_balance(tokenOut) >= balanceBefore, 'DePay: Insufficient balance after payment!');
+  }
+```
+```solidity
+ function _ensureBalance(address[] calldata path) private returns (uint balance) {
+    balance = _balance(path[path.length-1]);
+    if(path[path.length-1] == ZERO) { balance -= msg.value; }
+  }
+```
+
+<a name="L02"/>
+
+## L02 - Inconsistent variable types
+
+| Affected        | Severity  | Count | Lines |
+|:----------------|:----------|------:|-------:|
+| DePayPaymentProcessorV1.sol   | Low    |   1 |[14](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1Uniswap01.sol#L14)|
+| DePayPaymentProcessorV1Uniswap01 | Low    |   1   |[29](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1Uniswap01.sol#L29)|
+| DePayPaymentProcessorV1Uniswap01  | Low    |   1   |[30](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1Uniswap01.sol#L30)|
+| DePayPaymentProcessorV1Uniswap01   | Low    |   1   |[31](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1Uniswap01.sol#L31)|
+| DePayPaymentProcessorV1Uniswap01  | Low    |   1   |[42](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1Uniswap01.sol#L42)|
+
+Defined [here](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L12) in `DePayPaymentProcessorV1`
+
+
+Variable type `uint256` was used in the underlying contract library [TransferHelper](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/master/contracts/libraries/TransferHelper.sol) while `uint` is used in both [DePayPaymentProcessorV1Uniswap01](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/master/contracts/DePayPaymentProcessorV1Uniswap01.sol) and [DePayPaymentProcessorV1](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/master/contracts/DePayPaymentProcessorV1.sol). Note that `uint` and `uint256` may have the same byte space allocation but it is advised to use a consistent variable naming strategy throughout a codebase so as to improve readability and maintainability.
+
+
+
+<a name="L03"/>
+
+## L03 - Lack of comments on most functions
+
+| Affected        | Severity  | Count | Lines |
+|:----------------|:----------|------:|-------:|
+| DePayLiquidityStaking.sol   | Low    |   7  |[34](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L34), [55](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L55), [60](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L60), [68](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L68), [77](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L77), [85](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L85), [93](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L93), [98](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1.sol#L98)|
+
+Most of these internal functions in `DePayPaymentProcessorV1`  require a lot of explanation which can be done in comments, especially core external functions like [pay](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/dc5204fb96f9b0f53d733fb89e91e856c1db1dbb/contracts/DePayPaymentProcessorV1Uniswap01.sol#L27) in `DePayPaymentProcessorV1Uniswap01` .
+Consider adding comments that do a thorough explanation on how these functions use their arguments and the values they return
+
+<a name="N01"/>
+
+## N01 - Consider using address(0) 
+
+```solidity
+  // Address ZERO
+  address private ZERO = 0x0000000000000000000000000000000000000000;
+```
+
+To improve readability and also preserve some storage, consider using `address(0)`
+

--- a/contracts/DePayPaymentProcessorV1.sol
+++ b/contracts/DePayPaymentProcessorV1.sol
@@ -15,7 +15,7 @@ contract DePayPaymentProcessorV1 is Ownable {
   using SafeERC20 for IERC20;
 
   // Address ZERO indicating ETH transfer, because ETH does not have an address like other tokens
-  address private ZERO = 0x0000000000000000000000000000000000000000;
+  address private ZERO = address(0);
 
   // List of approved payment processors
   mapping (address => address) private processors;

--- a/contracts/DePayPaymentProcessorV1.sol
+++ b/contracts/DePayPaymentProcessorV1.sol
@@ -69,11 +69,6 @@ contract DePayPaymentProcessorV1 is Ownable {
     require(_balance(tokenOut) >= balanceBefore, 'DePay: Insufficient balance after payment!');
   }
 
-  function _ensureBalance(address[] calldata path) private returns (uint balance) {
-    balance = _balance(path[path.length-1]);
-    if(path[path.length-1] == ZERO) { balance -= msg.value; }
-  }
-
   function _balance(address token) private view returns(uint) {
     if(token == ZERO) {
         return address(this).balance;

--- a/contracts/DePayPaymentProcessorV1.sol
+++ b/contracts/DePayPaymentProcessorV1.sol
@@ -97,7 +97,7 @@ contract DePayPaymentProcessorV1 is Ownable {
     uint amountOut,
     uint deadline
   ) internal {
-    for (uint256 i = 0; i < _processors.length; i++) {
+    for (uint i = 0; i < _processors.length; i++) {
       require(_isApproved(_processors[i]), 'DePay: Processor not approved!');
       address processor = processors[_processors[i]];
       (bool success, bytes memory returnData) = processor.delegatecall(abi.encodeWithSelector(

--- a/contracts/DePayPaymentProcessorV1Uniswap01.sol
+++ b/contracts/DePayPaymentProcessorV1Uniswap01.sol
@@ -12,7 +12,7 @@ contract DePayPaymentProcessorV1Uniswap01 {
   using SafeMath for uint;
 
   uint public immutable MAXINT = (2**256)-1;
-  address public immutable ZERO = 0x0000000000000000000000000000000000000000;
+  address public immutable ZERO = address(0);
   address public immutable WETH;
   address public immutable UniswapV2Router02;
 


### PR DESCRIPTION
This PR implements improvements based on [audit #1](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/92004f11b4660fbc158b13ea0d83ef32bf289745/Audit1.md)

We will mitigate [**L03 - Lack of comments on most functions**](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/92004f11b4660fbc158b13ea0d83ef32bf289745/Audit1.md#l03---lack-of-comments-on-most-functions) in the [refactoring branch](https://github.com/DePayFi/depay-ethereum-payment-processing/pull/6).  
  
As we consider [TransferHelper](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/master/contracts/libraries/TransferHelper.sol) the bridge to ERC20, we will consistently use `uint` in our code, but can't change the implementation details of ERC20 can change the variable types in [TransferHelper](https://github.com/DePayFi/depay-ethereum-payment-processing/blob/master/contracts/libraries/TransferHelper.sol) to `uint` as ERC20 implements `uint256`.